### PR TITLE
fix: Working on (ISSUE) fix (ESC Website)

### DIFF
--- a/layout/_partial/git-history.ejs
+++ b/layout/_partial/git-history.ejs
@@ -1,0 +1,3 @@
+<a href="<%- githubBlame({ url: page.source })  %>" target="_blank">Blame</a> - 
+<a href="<%- githubCommits({ url: page.source }) %>" target="_blank">History</a>
+  

--- a/layout/_partial/git-history.js
+++ b/layout/_partial/git-history.js
@@ -1,3 +1,0 @@
-<a href="https://github.com/ES-Community/ES-Community.github.io/blame/source/source/<%= page.source %>" target="_blank">Blame</a> - 
-<a href="https://github.com/ES-Community/ES-Community.github.io/commits/source/source/<%= page.source %>" target="_blank">History</a>
-  

--- a/layout/post.ejs
+++ b/layout/post.ejs
@@ -17,7 +17,7 @@
   <div class="content" itemprop="articleBody">
     <%- page.content %>
   </div>
-  <%- partial('_partial/git-history.js') %>
+  <%- partial('_partial/git-history.ejs') %>
   <% if (page.author) { %>
     <div id="page-author" style="display:flex; justify-content: center; margin-top: 2em;">
       <%- githubCard({user: page.author}) %>

--- a/scripts/githubFooter.js
+++ b/scripts/githubFooter.js
@@ -1,0 +1,4 @@
+const repos = 'https://github.com/ES-Community/ES-Community.github.io'
+
+hexo.extend.helper.register('githubBlame', ({ url }) => `${repos}/blame/source/source/${url}`)
+hexo.extend.helper.register('githubCommits', ({ url }) => `${repos}/commits/source/source/${url}`)

--- a/scripts/githubFooter.js
+++ b/scripts/githubFooter.js
@@ -1,4 +1,5 @@
-const repos = 'https://github.com/ES-Community/ES-Community.github.io'
+// Get the deploy repo to use it in github query
+const repos = hexo.config.deploy.repo
 
 hexo.extend.helper.register('githubBlame', ({ url }) => `${repos}/blame/source/source/${url}`)
 hexo.extend.helper.register('githubCommits', ({ url }) => `${repos}/commits/source/source/${url}`)


### PR DESCRIPTION
Working on this [issue](https://github.com/ES-Community/ES-Community.github.io/issues/10).
With this commit, the issue should be done.

I juste have created a new Helper: (/scripts/githubFooter.js) like that:
```js
hexo.extend.helper.register('githubFooter', ({ url }) => url)
```
I have created a helper, if in a few days you want to update the behaviour of these links.

In next, i have renamed this file: /layout/_partial/git-history.js to /layout/_partial/git-history.ejs
and, to use the helper i have update the code with that: 
```ejs
<a href="https://github.com/ES-Community/ES-Community.github.io/blame/source/source/<%- githubFooter({ url: page.source })  %>" target="_blank">Blame</a> - 
<a href="https://github.com/ES-Community/ES-Community.github.io/commits/source/source/<%- githubFooter({ url: page.source }) %>" target="_blank">History</a>
  ```

Finally to use the new .ejs file i have update this file: /layout/post.ejs
(before)
```ejs
<%- partial('_partial/git-history.js') %>
```
by
```ejs
<%- partial('_partial/git-history.ejs') %>
```

I hope this will help you 🙏 

[EDIT] Commits number 2
Just added a new behaviors of the Helper like that:
```js
const repos = 'https://github.com/ES-Community/ES-Community.github.io'

hexo.extend.helper.register('githubBlame', ({ url }) => `${repos}/blame/source/source/${url}`)
hexo.extend.helper.register('githubCommits', ({ url }) => `${repos}/commits/source/source/${url}`)
```

I think is better to do the things like that.
So to work with that, i have updated this file: /layout/_partial/git-history.ejs with that,
```ejs
<a href="<%- githubBlame({ url: page.source })  %>" target="_blank">Blame</a> - 
<a href="<%- githubCommits({ url: page.source }) %>" target="_blank">History</a>
```
I think is more cleaner like that 😄 
  

